### PR TITLE
Optimize grid rendering and gaze tracking

### DIFF
--- a/accessmenttool/AmslerGrid/Assets/AmslerGrid.cs
+++ b/accessmenttool/AmslerGrid/Assets/AmslerGrid.cs
@@ -20,10 +20,7 @@ public class AmslerGrid : MonoBehaviour
     private Material lineMaterial; // Material for the LineRenderer
 
     [SerializeField]
-    private float lineWidth = .03f;
-
-    [SerializeField]
-    public Image circle; 
+    public Image circle;
 
     private float cmPerPixel;
     private float screenWidth;
@@ -116,35 +113,49 @@ public class AmslerGrid : MonoBehaviour
         float pixelsToWorldX = screenWidthWorld / screenResolution.x;
         float pixelsToWorldY = screenHeightWorld / screenResolution.y;
 
-        // Draw vertical lines
+        // Total line count (each line has two vertices)
+        int totalLines = numberOfVerticalLines + numberOfHorizontalLines;
+        Vector3[] vertices = new Vector3[totalLines * 2];
+        int[] indices = new int[totalLines * 2];
+        int vertIndex = 0;
+
+        // Store vertical line vertices
         for (int i = -numberOfVerticalLines / 2; i <= numberOfVerticalLines / 2; i++)
         {
             float xPos = i * distancePerLinePx * pixelsToWorldX;
-            DrawLine(new Vector3(xPos, -screenHeightWorld, 0), new Vector3(xPos, screenHeightWorld, 0), (i == 0) ? lineWidth + 0.01f : lineWidth);
+            vertices[vertIndex] = new Vector3(xPos, -screenHeightWorld, 0);
+            indices[vertIndex] = vertIndex;
+            vertIndex++;
+            vertices[vertIndex] = new Vector3(xPos, screenHeightWorld, 0);
+            indices[vertIndex] = vertIndex;
+            vertIndex++;
         }
 
-        // Draw horizontal lines
+        // Store horizontal line vertices
         for (int i = -numberOfHorizontalLines / 2; i <= numberOfHorizontalLines / 2; i++)
         {
             float yPos = i * distancePerLinePx * pixelsToWorldY;
-            DrawLine(new Vector3(-screenWidthWorld, yPos, 0), new Vector3(screenWidthWorld, yPos, 0), (i == 0) ? lineWidth + 0.01f : lineWidth);
+            vertices[vertIndex] = new Vector3(-screenWidthWorld, yPos, 0);
+            indices[vertIndex] = vertIndex;
+            vertIndex++;
+            vertices[vertIndex] = new Vector3(screenWidthWorld, yPos, 0);
+            indices[vertIndex] = vertIndex;
+            vertIndex++;
         }
-    }
 
-    void DrawLine(Vector3 start, Vector3 end, float width)
-    {
-        GameObject lineObj = new GameObject("Line");
-        LineRenderer lineRenderer = lineObj.AddComponent<LineRenderer>();
-        drawnObjects.Add(lineRenderer.gameObject);
-        lineRenderer.transform.parent = transform;
+        // Create mesh for the grid
+        Mesh gridMesh = new Mesh();
+        gridMesh.vertices = vertices;
+        gridMesh.SetIndices(indices, MeshTopology.Lines, 0);
 
-        lineRenderer.positionCount = 2;
-        lineRenderer.SetPosition(0, start);
-        lineRenderer.SetPosition(1, end);
+        GameObject gridObj = new GameObject("Grid");
+        gridObj.transform.parent = transform;
+        MeshFilter mf = gridObj.AddComponent<MeshFilter>();
+        MeshRenderer mr = gridObj.AddComponent<MeshRenderer>();
+        mf.mesh = gridMesh;
+        mr.material = lineMaterial;
 
-        lineRenderer.startWidth = width; 
-        lineRenderer.endWidth = width;
-        lineRenderer.material = lineMaterial;
+        drawnObjects.Add(gridObj);
     }
 
     void CheckVisablility()

--- a/macos/Assets/Scripts/GazeTracker.cs
+++ b/macos/Assets/Scripts/GazeTracker.cs
@@ -34,6 +34,8 @@ public class GazeTracker : MonoBehaviour
 
     // Cache reference to the Gaze component instead of searching every frame
     private Gaze gazeScript;
+    // Cache the active state of the unitEye object
+    private bool unitEyeActive = false;
 
     // Singleton
     private static GazeTracker instance; // Singleton instance
@@ -71,7 +73,7 @@ public class GazeTracker : MonoBehaviour
 	void Update ()
     {
         switch (gazeSource) {
-		case GazeSource.Fove:
+                case GazeSource.Fove:
                 /*
         	// Get convergence data
 			Fove.Managed.SFVR_GazeConvergenceData convergence = FoveInterface2.GetFVRHeadset ().GetGazeConvergence ();
@@ -89,7 +91,11 @@ public class GazeTracker : MonoBehaviour
 			break;
             */
         case GazeSource.UnitEye:
-                unitEye.SetActive(true);
+                if (!unitEyeActive)
+                {
+                    unitEye.SetActive(true);
+                    unitEyeActive = true;
+                }
                 xy_norm = FindGazeLocation();
                 xy_norm.x = xy_norm.x / Screen.width;
                 xy_norm.y = (Screen.height - xy_norm.y) / Screen.height;
@@ -126,10 +132,14 @@ public class GazeTracker : MonoBehaviour
                 */
                 break;
         case GazeSource.Mouse:
-            unitEye.SetActive(false);
-         	// Get raw, clip within canvas
-			float mousex = Mathf.Min (Mathf.Max (Input.mousePosition.x, 0), Screen.width);
-			float mousey = Mathf.Min (Mathf.Max (Input.mousePosition.y, 0), Screen.height);
+            if (unitEyeActive)
+            {
+                unitEye.SetActive(false);
+                unitEyeActive = false;
+            }
+                // Get raw, clip within canvas
+                        float mousex = Mathf.Min (Mathf.Max (Input.mousePosition.x, 0), Screen.width);
+                        float mousey = Mathf.Min (Mathf.Max (Input.mousePosition.y, 0), Screen.height);
 
             // Convert to norm & set
 			xy_norm.x = mousex / Screen.width;
@@ -139,20 +149,26 @@ public class GazeTracker : MonoBehaviour
 
             // finished Mouse
             break;
-		case GazeSource.None:
-         	// fix at centre
-			xy_norm.x = 0.5f;
-			xy_norm.y = 0.5f;
+                case GazeSource.None:
+                // fix at centre
+                        xy_norm.x = 0.5f;
+                        xy_norm.y = 0.5f;
 
-         	// finished None
-			break;
-		default:
-			throw new System.ArgumentException ("Unknown GazeSource parameter?");
-		}
+                if (unitEyeActive)
+                {
+                    unitEye.SetActive(false);
+                    unitEyeActive = false;
+                }
+
+                // finished None
+                        break;
+                default:
+                        throw new System.ArgumentException ("Unknown GazeSource parameter?");
+                }
 
         // clamp within 0 to 1 range (defensive)
-        xy_norm.x = Mathf.Min(Mathf.Max(xy_norm.x, 0f), 1f);
-        xy_norm.y = Mathf.Min(Mathf.Max(xy_norm.y, 0f), 1f);
+        xy_norm.x = Mathf.Clamp01(xy_norm.x);
+        xy_norm.y = Mathf.Clamp01(xy_norm.y);
     }
 
     void OnGUI()

--- a/windows/Assets/Scripts/GazeTracker.cs
+++ b/windows/Assets/Scripts/GazeTracker.cs
@@ -33,6 +33,8 @@ public class GazeTracker : MonoBehaviour
 
     // Cache reference to the Gaze component instead of searching every frame
     private Gaze gazeScript;
+    // Cache the active state of the unitEye object
+    private bool unitEyeActive = false;
 
     // Singleton
     private static GazeTracker instance; // Singleton instance
@@ -70,7 +72,7 @@ public class GazeTracker : MonoBehaviour
 	void Update ()
     {
         switch (gazeSource) {
-		case GazeSource.Fove:
+                case GazeSource.Fove:
                 /*
         	// Get convergence data
 			Fove.Managed.SFVR_GazeConvergenceData convergence = FoveInterface2.GetFVRHeadset ().GetGazeConvergence ();
@@ -88,7 +90,11 @@ public class GazeTracker : MonoBehaviour
 			break;
             */
         case GazeSource.UnitEye:
-                unitEye.SetActive(true);
+                if (!unitEyeActive)
+                {
+                    unitEye.SetActive(true);
+                    unitEyeActive = true;
+                }
                 xy_norm = FindGazeLocation();
                 xy_norm.x = xy_norm.x / Screen.width;
                 xy_norm.y = (Screen.height - xy_norm.y) / Screen.height;
@@ -125,10 +131,14 @@ public class GazeTracker : MonoBehaviour
                 */
                 break;
         case GazeSource.Mouse:
-            unitEye.SetActive(false);
-         	// Get raw, clip within canvas
-			float mousex = Mathf.Min (Mathf.Max (Input.mousePosition.x, 0), Screen.width);
-			float mousey = Mathf.Min (Mathf.Max (Input.mousePosition.y, 0), Screen.height);
+            if (unitEyeActive)
+            {
+                unitEye.SetActive(false);
+                unitEyeActive = false;
+            }
+                // Get raw, clip within canvas
+                        float mousex = Mathf.Min (Mathf.Max (Input.mousePosition.x, 0), Screen.width);
+                        float mousey = Mathf.Min (Mathf.Max (Input.mousePosition.y, 0), Screen.height);
 
             // Convert to norm & set
 			xy_norm.x = mousex / Screen.width;
@@ -138,20 +148,26 @@ public class GazeTracker : MonoBehaviour
 
             // finished Mouse
             break;
-		case GazeSource.None:
-         	// fix at centre
-			xy_norm.x = 0.5f;
-			xy_norm.y = 0.5f;
+                case GazeSource.None:
+                // fix at centre
+                        xy_norm.x = 0.5f;
+                        xy_norm.y = 0.5f;
 
-         	// finished None
-			break;
-		default:
-			throw new System.ArgumentException ("Unknown GazeSource parameter?");
-		}
+                if (unitEyeActive)
+                {
+                    unitEye.SetActive(false);
+                    unitEyeActive = false;
+                }
+
+                // finished None
+                        break;
+                default:
+                        throw new System.ArgumentException ("Unknown GazeSource parameter?");
+                }
 
         // clamp within 0 to 1 range (defensive)
-        xy_norm.x = Mathf.Min(Mathf.Max(xy_norm.x, 0f), 1f);
-        xy_norm.y = Mathf.Min(Mathf.Max(xy_norm.y, 0f), 1f);
+        xy_norm.x = Mathf.Clamp01(xy_norm.x);
+        xy_norm.y = Mathf.Clamp01(xy_norm.y);
     }
 
     void OnGUI()


### PR DESCRIPTION
## Summary
- Render Amsler grid via single mesh to avoid creating many line objects
- Cache `unitEye` activation and clamp gaze values in GazeTracker for efficiency

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8dfa9b48332b68658e543a45ed2