### PR TITLE
Use single SetPixels call in noise texture generation

### DIFF
--- a/macos/Assets/Scripts/NoiseTextureGenerator.cs
+++ b/macos/Assets/Scripts/NoiseTextureGenerator.cs
@@ -10,6 +10,8 @@ public class NoiseTextureGenerator : MonoBehaviour
     void Start()
     {
         Texture2D noiseTex = new Texture2D(width, height);
+        Color[] colors = new Color[width * height];
+
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
@@ -17,9 +19,11 @@ public class NoiseTextureGenerator : MonoBehaviour
                 float xCoord = (float)x / width * scale;
                 float yCoord = (float)y / height * scale;
                 float sample = Mathf.PerlinNoise(xCoord, yCoord);
-                noiseTex.SetPixel(x, y, new Color(sample, sample, sample));
+                colors[y * width + x] = new Color(sample, sample, sample);
             }
         }
+
+        noiseTex.SetPixels(colors);
         noiseTex.Apply();
         GetComponent<Renderer>().material.SetTexture("_NoiseTex", noiseTex);
     }


### PR DESCRIPTION
## Summary
- Generate noise texture colors in an array instead of calling SetPixel per coordinate
- Batch assign pixels with SetPixels for improved efficiency

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c5acefa5f483329b94a278e4235f56