### PR TITLE
Add brush pooling utility to reuse LineRenderer objects

### DIFF
--- a/accessmenttool/AmslerGrid/Assets/BrushPool.cs
+++ b/accessmenttool/AmslerGrid/Assets/BrushPool.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Simple object pool for brush instances to avoid frequent instantiation
+/// and destruction of LineRenderer objects.
+/// </summary>
+public class BrushPool : MonoBehaviour
+{
+    // Prefab used to create new brush instances when the pool is empty.
+    public GameObject brushPrefab;
+
+    // Queue storing available brush instances.
+    private readonly Queue<GameObject> pool = new Queue<GameObject>();
+
+    /// <summary>
+    /// Retrieves a brush from the pool or instantiates a new one if none
+    /// are available. The brush is reset to a default state before
+    /// returning.
+    /// </summary>
+    public GameObject GetBrush()
+    {
+        GameObject brushInstance = pool.Count > 0 ? pool.Dequeue() : Instantiate(brushPrefab);
+
+        brushInstance.SetActive(true);
+
+        // Reset the LineRenderer so the new line starts clean.
+        LineRenderer lr = brushInstance.GetComponent<LineRenderer>();
+        lr.positionCount = 2;
+        lr.SetPosition(0, Vector3.zero);
+        lr.SetPosition(1, Vector3.zero);
+
+        return brushInstance;
+    }
+
+    /// <summary>
+    /// Returns a brush to the pool after resetting it. The object is
+    /// deactivated and stored for future reuse.
+    /// </summary>
+    public void ReturnBrush(GameObject brushInstance)
+    {
+        LineRenderer lr = brushInstance.GetComponent<LineRenderer>();
+        lr.positionCount = 2;
+        lr.SetPosition(0, Vector3.zero);
+        lr.SetPosition(1, Vector3.zero);
+
+        brushInstance.SetActive(false);
+        brushInstance.transform.SetParent(transform);
+        pool.Enqueue(brushInstance);
+    }
+}
+

--- a/accessmenttool/AmslerGrid/Assets/BrushPool.cs.meta
+++ b/accessmenttool/AmslerGrid/Assets/BrushPool.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8b3a4725d0f84e6fbfdcd544a2ce01e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+

--- a/accessmenttool/AmslerGrid/Assets/MarkerTool.cs
+++ b/accessmenttool/AmslerGrid/Assets/MarkerTool.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 public class MarkerTool : MonoBehaviour
 {
     public Camera m_camera;
-    public GameObject brush;
+    public BrushPool brushPool;
 
     public Material white;
     public Material blue;
@@ -48,7 +48,7 @@ public class MarkerTool : MonoBehaviour
 
     void CreateBrush()
     {
-        GameObject brushInstance = Instantiate(brush);
+        GameObject brushInstance = brushPool.GetBrush();
         brushInstance.GetComponent<LineRenderer>().material = currentMaterial;
         drawnObjects.Add(brushInstance);
         brushInstance.transform.parent = transform;
@@ -116,7 +116,7 @@ public class MarkerTool : MonoBehaviour
         {
             GameObject lastDrawnObject = drawnObjects[drawnObjects.Count - 1];
             drawnObjects.RemoveAt(drawnObjects.Count - 1);
-            Destroy(lastDrawnObject);
+            brushPool.ReturnBrush(lastDrawnObject);
         }
     }
 


### PR DESCRIPTION
## Summary
- add BrushPool component to recycle LineRenderer brush objects
- switch MarkerTool to obtain brushes from pool and return them on undo

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae17bf4c8332943670fb48ffbe74