### PR TITLE
Fix parameter typos and unify strength field

### DIFF
--- a/macos/Assets/Scenes/VIP_SIM.unity
+++ b/macos/Assets/Scenes/VIP_SIM.unity
@@ -16725,7 +16725,7 @@ MonoBehaviour:
     i_threshold: 0
     displacementAmount: 0
     vortexRadius: 0
-    suctionStrenght: 0
+    suctionStrength: 0
     innerCircleRadius: 0
     noiseAmount: 0
     innnerCircleRadius: 0

--- a/macos/Assets/Scripts/DropdownManager.cs
+++ b/macos/Assets/Scripts/DropdownManager.cs
@@ -44,7 +44,6 @@ public class DropdownManager : MonoBehaviour
         fixedInputs.Add("Rise_d");
         fixedInputs.Add("Rise_exp");
         fixedInputs.Add("Amp_deg");
-        fixedInputs.Add("BaslineErr_deg");
         fixedInputs.Add("kernalSigma");
         fixedInputs.Add("viewingAngle_deg");
         fixedInputs.Add("AutomaticTimer");
@@ -264,7 +263,7 @@ public class DropdownManager : MonoBehaviour
         { "Speed", "Speed (-/+)" },
         { "displacementAmount", "Severity (-/+)" },
         { "vortexRadius", "Radius (-/+)" },
-        { "suctionStrength", "Strenght (-/+)" },
+        { "suctionStrength", "Strength (-/+)" },
         { "innerCircleRadius", "Radius (-/+)" },
         { "noiseAmount", "Noise (-/+)" },
         { "fadeWidth", "Fade (-/+)" },
@@ -276,7 +275,7 @@ public class DropdownManager : MonoBehaviour
         { "pixelRadius", "Strength (-/+)" },
         { "intensity", "Intensity (-/+)" },
         { "blurSize", "Size (-/+)" },
-        { "Strength", "Strenght (-/+)" },
+        { "Strength", "Strength (-/+)" },
         { "Frequency", "Frequency (-/+)" },
         { "Amplitude", "Amplitude (-/+)" },
         { "threshold", "Threshold (-/+)" },

--- a/macos/Assets/Scripts/SettingsManager.cs
+++ b/macos/Assets/Scripts/SettingsManager.cs
@@ -177,7 +177,7 @@ private void Start()
         myDoubleVision.displacementAmount = appSettings.displacementAmount;
         //Distortion
         myVortexEffect.vortexRadius = appSettings.vortexRadius;
-        myVortexEffect.suctionStrength = appSettings.suctionStrenght;
+        myVortexEffect.suctionStrength = appSettings.suctionStrength;
         myVortexEffect.innerCircleRadius = appSettings.innerCircleRadius;
         myVortexEffect.noiseAmount = appSettings.noiseAmount;
         //Foveal Darkness
@@ -247,7 +247,7 @@ private void Start()
         appSettings.displacementAmount = myDoubleVision.displacementAmount;
         // Distortion
         appSettings.vortexRadius = myVortexEffect.vortexRadius;
-        appSettings.suctionStrenght = myVortexEffect.suctionStrength;
+        appSettings.suctionStrength = myVortexEffect.suctionStrength;
         appSettings.innerCircleRadius = myVortexEffect.innerCircleRadius;
         appSettings.noiseAmount = myVortexEffect.noiseAmount;
         // Foveal Darkness
@@ -328,7 +328,7 @@ public class AppSettings
     public float displacementAmount;
     //Distortion
     public float vortexRadius;
-    public float suctionStrenght;
+    public float suctionStrength;
     public float innerCircleRadius;
     public float noiseAmount;
     //Foveal Darkness

--- a/windows/Assets/Scenes/VIP_SIM.unity
+++ b/windows/Assets/Scenes/VIP_SIM.unity
@@ -22492,7 +22492,7 @@ MonoBehaviour:
     i_threshold: 0
     displacementAmount: 0
     vortexRadius: 0
-    suctionStrenght: 0
+    suctionStrength: 0
     innerCircleRadius: 0
     noiseAmount: 0
     innnerCircleRadius: 0

--- a/windows/Assets/Scripts/DropdownManager.cs
+++ b/windows/Assets/Scripts/DropdownManager.cs
@@ -44,7 +44,6 @@ public class DropdownManager : MonoBehaviour
         fixedInputs.Add("Rise_d");
         fixedInputs.Add("Rise_exp");
         fixedInputs.Add("Amp_deg");
-        fixedInputs.Add("BaslineErr_deg");
         fixedInputs.Add("kernalSigma");
         fixedInputs.Add("viewingAngle_deg");
         fixedInputs.Add("AutomaticTimer");
@@ -265,7 +264,7 @@ public class DropdownManager : MonoBehaviour
         { "Speed", "Speed (-/+)" },
         { "displacementAmount", "Severity (-/+)" },
         { "vortexRadius", "Radius (-/+)" },
-        { "suctionStrength", "Strenght (-/+)" },
+        { "suctionStrength", "Strength (-/+)" },
         { "innerCircleRadius", "Radius (-/+)" },
         { "noiseAmount", "Noise (-/+)" },
         { "fadeWidth", "Fade (-/+)" },

--- a/windows/Assets/VisualEffects/Profiles/SettingsManager.cs
+++ b/windows/Assets/VisualEffects/Profiles/SettingsManager.cs
@@ -1,14 +1,14 @@
 using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
-using Newtonsoft.Json; // Für JSON (installiere NewtonSoft.Json aus dem Unity Asset Store oder per NuGet)
+using Newtonsoft.Json; // FÃ¼r JSON (installiere NewtonSoft.Json aus dem Unity Asset Store oder per NuGet)
 using System.Reflection;
 using MathNet.Numerics.Interpolation;
 using System.Threading.Tasks;
 using VisSim;
 using static VisSim.myRecolour;
 using static VisSim.myFloaters;
-using SimpleFileBrowser; // Für Reflection, um alle Public Variablen zu aktualisieren
+using SimpleFileBrowser; // FÃ¼r Reflection, um alle Public Variablen zu aktualisieren
 
 public class SettingsManager : MonoBehaviour
 {
@@ -75,13 +75,13 @@ public class SettingsManager : MonoBehaviour
 
     private void Start()
     {
-        // Event Listener für die Buttons hinzufügen
+        // Event Listener fÃ¼r die Buttons hinzufÃ¼gen
         loadButton.onClick.AddListener(OpenFileBrowser);
         saveButton.onClick.AddListener(SaveSettings);
         InvokeRepeating("SyncSettings", 5.0f, 5.0f);
     }
 
-    // Öffnet einen Dateibrowser, um die Datei zu laden
+    // Ã–ffnet einen Dateibrowser, um die Datei zu laden
     private async void OpenFileBrowser()
     {
         string path = await OpenFilePanelAsync();
@@ -103,14 +103,14 @@ public class SettingsManager : MonoBehaviour
         }
     }
 
-    // Lädt Einstellungen aus einer JSON-Datei
+    // LÃ¤dt Einstellungen aus einer JSON-Datei
     private void LoadSettings(string path)
     {
         if (File.Exists(path))
         {
             string json = File.ReadAllText(path);
             appSettings = JsonConvert.DeserializeObject<AppSettings>(json);
-            ApplySettings(); // Übernimmt die Einstellungen ins Spiel
+            ApplySettings(); // Ãœbernimmt die Einstellungen ins Spiel
             Debug.Log("Settings loaded from: " + path);
         }
         else
@@ -119,7 +119,7 @@ public class SettingsManager : MonoBehaviour
         }
     }
 
-    // Übernimmt die geladenen Einstellungen und aktualisiert alle relevanten Public Variablen in anderen Skripten
+    // Ãœbernimmt die geladenen Einstellungen und aktualisiert alle relevanten Public Variablen in anderen Skripten
     private void ApplySettings()
     {
         // Aktualisiere alle Objekte mit Public Variablen
@@ -129,7 +129,7 @@ public class SettingsManager : MonoBehaviour
             UpdatePublicFields();
         }
 
-        // Beispiel: wende Licht-Intensität an
+        // Beispiel: wende Licht-IntensitÃ¤t an
         Light[] lights = FindObjectsOfType<Light>();
         foreach (var light in lights)
         {
@@ -190,7 +190,7 @@ public class SettingsManager : MonoBehaviour
         myDoubleVision.displacementAmount = appSettings.displacementAmount;
         //Distortion
         myVortexEffect.vortexRadius = appSettings.vortexRadius;
-        myVortexEffect.suctionStrength = appSettings.suctionStrenght;
+        myVortexEffect.suctionStrength = appSettings.suctionStrength;
         myVortexEffect.innerCircleRadius = appSettings.innerCircleRadius;
         myVortexEffect.noiseAmount = appSettings.noiseAmount;
         //Foveal Darkness
@@ -207,7 +207,7 @@ public class SettingsManager : MonoBehaviour
 
 }
 
-    // Synchronisiert die AppSettings, wenn sich eine Public Variable ändert
+    // Synchronisiert die AppSettings, wenn sich eine Public Variable Ã¤ndert
     public void SyncSettings()
     {
         // vision loss central
@@ -260,7 +260,7 @@ public class SettingsManager : MonoBehaviour
         appSettings.displacementAmount = myDoubleVision.displacementAmount;
         // Distortion
         appSettings.vortexRadius = myVortexEffect.vortexRadius;
-        appSettings.suctionStrenght = myVortexEffect.suctionStrength;
+        appSettings.suctionStrength = myVortexEffect.suctionStrength;
         appSettings.innerCircleRadius = myVortexEffect.innerCircleRadius;
         appSettings.noiseAmount = myVortexEffect.noiseAmount;
         // Foveal Darkness
@@ -277,7 +277,7 @@ public class SettingsManager : MonoBehaviour
 
     }
 
-    // Methoden für den Standalone File Browser
+    // Methoden fÃ¼r den Standalone File Browser
     /*
     private string OpenFilePanel()
     {
@@ -333,7 +333,7 @@ public class SettingsManager : MonoBehaviour
     }
 }
 
-// Klasse, die alle Einstellungen enthält
+// Klasse, die alle Einstellungen enthÃ¤lt
 [System.Serializable]
 public class AppSettings
 {
@@ -344,7 +344,7 @@ public class AppSettings
     public bool fullscreen = true;
     public float volume = 0.5f;
 
-    // Füge hier weitere Einstellungen hinzu, die gespeichert werden sollen
+    // FÃ¼ge hier weitere Einstellungen hinzu, die gespeichert werden sollen
 
     // vision loss central
     public float overlay_scale;
@@ -396,7 +396,7 @@ public class AppSettings
     public float displacementAmount;
     //Distortion
     public float vortexRadius;
-    public float suctionStrenght;
+    public float suctionStrength;
     public float innerCircleRadius;
     public float noiseAmount;
     //Foveal Darkness


### PR DESCRIPTION
## Summary
- remove duplicate baselineErr entry from DropdownManager and correct strength labels
- rename suctionStrenght to suctionStrength across scripts and scenes for consistent distortion settings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b68058888332bafb7781f9f2197a