### PR TITLE
Optimize background performance for persistent use

### DIFF
--- a/windows/Assets/Scripts/HideImpairmentSelection.cs
+++ b/windows/Assets/Scripts/HideImpairmentSelection.cs
@@ -4,32 +4,27 @@ using uWindowCapture;
 
 public class HideImpairmentSelection : MonoBehaviour
 {
-    // Serielles Field für das GameObject, das gesetzt werden soll
     [SerializeField] private GameObject targetGameObject;
     [SerializeField] Slider enableToggle;
     [SerializeField] Image settingWheel;
 
-    // Update is called once per frame
     void Update()
     {
-        // Setzt das target GameObject je nach Rückgabewert
-        if (UwcWindowList.thereIsActiveWindow)
+        bool hasActiveWindow = UwcWindowList.thereIsActiveWindow;
+        bool desiredActive = hasActiveWindow && enableToggle.value > 0.9f;
+
+        if (targetGameObject.activeSelf != desiredActive)
         {
-            if (enableToggle.value > 0.9)
-            {
-                targetGameObject.SetActive(true);
-            } else
-            {
-                targetGameObject.SetActive(false);
-            }
-            if(settingWheel != null)
-            settingWheel.enabled = true;
+            targetGameObject.SetActive(desiredActive);
         }
-        else
+
+        if (settingWheel != null)
         {
-            targetGameObject.SetActive(false);
-            if(settingWheel != null)
-            settingWheel.enabled = false;    
+            bool desiredWheel = hasActiveWindow;
+            if (settingWheel.enabled != desiredWheel)
+            {
+                settingWheel.enabled = desiredWheel;
+            }
         }
     }
 }

--- a/windows/Assets/Scripts/ScaleManager.cs
+++ b/windows/Assets/Scripts/ScaleManager.cs
@@ -7,21 +7,46 @@ public class ScaleManager : MonoBehaviour
 {
     public Camera cam;
 
-    // Start is called before the first frame update
+    private Vector3 lastCamPos;
+    private Quaternion lastCamRot;
+    private float lastFov;
+    private int lastScreenW;
+    private int lastScreenH;
+
     void Start()
     {
-
+        CacheValues();
+        UpdateScale();
     }
 
-    // Update is called once per frame
     void Update()
     {
+        if (cam.transform.position != lastCamPos ||
+            cam.transform.rotation != lastCamRot ||
+            Math.Abs(cam.fieldOfView - lastFov) > Mathf.Epsilon ||
+            Screen.width != lastScreenW ||
+            Screen.height != lastScreenH)
+        {
+            CacheValues();
+            UpdateScale();
+        }
+    }
 
-        float pos = (cam.nearClipPlane + 10.0f);
+    private void CacheValues()
+    {
+        lastCamPos = cam.transform.position;
+        lastCamRot = cam.transform.rotation;
+        lastFov = cam.fieldOfView;
+        lastScreenW = Screen.width;
+        lastScreenH = Screen.height;
+    }
 
+    private void UpdateScale()
+    {
+        float pos = cam.nearClipPlane + 10.0f;
         transform.position = cam.transform.position + cam.transform.forward * pos;
         transform.LookAt(cam.transform);
-        float h = (Mathf.Tan(cam.fieldOfView * Mathf.Deg2Rad * 0.5f) * pos * 2f) * cam.aspect / 10.0f;
+        float h = Mathf.Tan(cam.fieldOfView * Mathf.Deg2Rad * 0.5f) * pos * 2f * cam.aspect / 10.0f;
         float w = h * Screen.height / Screen.width;
         transform.localScale = new Vector3(h, w, 1);
     }

--- a/windows/Assets/Scripts/TransparentWindow.cs
+++ b/windows/Assets/Scripts/TransparentWindow.cs
@@ -59,6 +59,7 @@ public class TransparentWindow : MonoBehaviour {
 
     private IntPtr hWnd;
     private bool _lastClickthrough;
+    private Coroutine clickRoutine;
 
     private void Start() {
         //MessageBox(new IntPtr(0), "Hello World!", "Hello Dialog", 0);
@@ -92,17 +93,36 @@ public class TransparentWindow : MonoBehaviour {
         feedbackState = false;
     }
 
-    private void Update() {
-        //SetClickthrough(Physics2D.OverlapPoint(GetMouseWorldPosition()) == null);
-        bool clickthrough = IsCoordinateOutsidePanel();
-        if (feedbackState)
+    private void OnEnable()
+    {
+        // Run the clickthrough check at a reduced frequency to lower CPU usage
+        clickRoutine = StartCoroutine(ClickthroughRoutine());
+    }
+
+    private void OnDisable()
+    {
+        if (clickRoutine != null)
         {
-            clickthrough = false;
+            StopCoroutine(clickRoutine);
         }
-        if (clickthrough != _lastClickthrough)
+    }
+
+    private IEnumerator ClickthroughRoutine()
+    {
+        var wait = new WaitForSeconds(0.1f); // Check 10 times per second
+        while (true)
         {
-            SetClickthrough(clickthrough);
-            _lastClickthrough = clickthrough;
+            bool clickthrough = IsCoordinateOutsidePanel();
+            if (feedbackState)
+            {
+                clickthrough = false;
+            }
+            if (clickthrough != _lastClickthrough)
+            {
+                SetClickthrough(clickthrough);
+                _lastClickthrough = clickthrough;
+            }
+            yield return wait;
         }
     }
 


### PR DESCRIPTION
## Summary
- Reduce clickthrough polling to 10Hz using coroutine in TransparentWindow to cut CPU usage when running in the background.
- Update ScaleManager only when camera or screen settings change to avoid redundant per-frame math.
- Toggle impairment selection UI elements only when their visibility actually changes.

## Testing
- `mcs windows/Assets/Scripts/ScaleManager.cs` *(fails: The type or namespace name `UnityEngine` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c1db128483329689695789bdfa01