### PR TITLE
Cache webcam name updates in Windows CamSelection

### DIFF
--- a/windows/Assets/Scripts/CamSelection.cs
+++ b/windows/Assets/Scripts/CamSelection.cs
@@ -14,36 +14,47 @@ public class CamSelection : MonoBehaviour
     [SerializeField]
     private Gaze gaze;
 
-    
+    private string previousName;
+
     private void Start()
     {
+        previousName = webCamInput.webCamName;
         StartCoroutine(LateStart(1));
     }
 
     private void Update()
     {
-        webcamtext.text = "Webcam:" + webCamInput.webCamName;
+        if (webCamInput.webCamName != previousName)
+        {
+            UpdateWebcamText();
+        }
     }
-
 
     IEnumerator LateStart(float waitTime)
     {
         yield return new WaitForSeconds(waitTime);
         //Your Function You Want to Call
-        webcamtext.text = webCamInput.webCamName;
+        UpdateWebcamText();
     }
 
     public void OnPrevCam()
     {
         webCamInput.PreviousCamera((int)webCamInput.webCamResolution.x, (int)webCamInput.webCamResolution.y);
         gaze.EyeHelper.CameraChanged(webCamInput.webCamName);
+        UpdateWebcamText();
     }
 
     public void OnNextCam()
     {
         webCamInput.NextCamera((int)webCamInput.webCamResolution.x, (int)webCamInput.webCamResolution.y);
         gaze.EyeHelper.CameraChanged(webCamInput.webCamName);
+        UpdateWebcamText();
     }
-    
-    
+
+    private void UpdateWebcamText()
+    {
+        previousName = webCamInput.webCamName;
+        webcamtext.text = "Webcam: " + previousName;
+    }
 }
+


### PR DESCRIPTION
## Summary
- Cache last selected webcam name and update the display only when the camera changes
- Align Windows CamSelection behavior with macOS version, including updates after manual camera switches

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6919e53488332865f3030b71ea801