### PR TITLE
Optimize camera alignment scripts

### DIFF
--- a/windows/Assets/Scripts/CameraMover.cs
+++ b/windows/Assets/Scripts/CameraMover.cs
@@ -1,17 +1,36 @@
 using UnityEngine;
-using UnityEngine.EventSystems;
+using UnityEngine.Serialization;
 
 public class CameraMover : MonoBehaviour
 {
+    [SerializeField, FormerlySerializedAs("cameraToMove")]
+    private Camera targetCamera;
 
-    public Camera cameraToMove;
-    public float moveSpeed = 0.1f;
+    private Camera cachedCamera;
 
-    void OnMouseDrag()
+    private void Awake()
     {
-        float distance_to_screen = Camera.main.WorldToScreenPoint(gameObject.transform.position).z;
-        Vector3 pos_move = Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, distance_to_screen));
-        transform.position = new Vector3(pos_move.x, transform.position.y, pos_move.z);
+        cachedCamera = targetCamera != null ? targetCamera : Camera.main;
+        if (cachedCamera == null)
+        {
+            Debug.LogError("CameraMover requires a Camera reference.", this);
+        }
+    }
 
+    private void OnMouseDrag()
+    {
+        if (cachedCamera == null)
+        {
+            return;
+        }
+
+        float distanceToScreen = cachedCamera.WorldToScreenPoint(transform.position).z;
+        Vector3 screenPoint = new Vector3(Input.mousePosition.x, Input.mousePosition.y, distanceToScreen);
+        Vector3 worldPosition = cachedCamera.ScreenToWorldPoint(screenPoint);
+
+        Vector3 currentPosition = transform.position;
+        currentPosition.x = worldPosition.x;
+        currentPosition.z = worldPosition.z;
+        transform.position = currentPosition;
     }
 }

--- a/windows/Assets/Scripts/FitPlaneToCameraView.cs
+++ b/windows/Assets/Scripts/FitPlaneToCameraView.cs
@@ -3,74 +3,124 @@ using UnityEngine;
 public class FitPlaneToCameraView : MonoBehaviour
 {
     public Camera mainCamera; // Reference to the main camera
-    private Transform planeTransform; // Reference to the plane's transform
 
-    void Start()
+    private Transform planeTransform; // Reference to the plane's transform
+    private MeshRenderer planeRenderer;
+    private bool missingPlaneLogged;
+    private bool missingRendererLogged;
+
+    private Vector3 lastBoundsSize;
+    private Vector3 lastBoundsCenter;
+    private float lastFieldOfView = float.NaN;
+    private float lastAspect = float.NaN;
+    private bool missingCameraLogged;
+
+    private void Awake()
     {
-        planeTransform = GetFirstChildTransform();
+        CachePlaneReferences();
+    }
+
+    private void OnEnable()
+    {
+        TryFitPlane(true);
+    }
+
+    private void Start()
+    {
+        TryFitPlane(true);
+    }
+
+    private void LateUpdate()
+    {
+        TryFitPlane(false);
+    }
+
+    private void CachePlaneReferences()
+    {
+        planeTransform = transform.childCount > 0 ? transform.GetChild(0) : null;
         if (planeTransform == null)
         {
-            Debug.LogError("No child found in the parent object.");
-        }
-    }
-
-    void Update()
-    {
-        planeTransform = GetFirstChildTransform();
-        if (planeTransform != null)
-        {
-            Debug.Log("Fit plane");
-            FitPlane();
-        }
-    }
-
-    Transform GetFirstChildTransform()
-    {
-        if (transform.childCount > 0)
-        {
-            return transform.GetChild(0);
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    void FitPlane()
-    {
-        if (mainCamera == null || planeTransform == null)
-        {
-            Debug.LogError("Main camera or plane transform not assigned.");
+            planeRenderer = null;
+            if (!missingPlaneLogged)
+            {
+                Debug.LogError("No child found in the parent object.");
+                missingPlaneLogged = true;
+            }
             return;
         }
 
-        // Get the mesh bounds of the plane
-        MeshRenderer planeRenderer = planeTransform.GetComponent<MeshRenderer>();
+        missingPlaneLogged = false;
+
+        planeRenderer = planeTransform.GetComponent<MeshRenderer>();
         if (planeRenderer == null)
         {
-            Debug.LogError("Plane does not have a MeshRenderer component.");
+            if (!missingRendererLogged)
+            {
+                Debug.LogError("Plane does not have a MeshRenderer component.");
+                missingRendererLogged = true;
+            }
             return;
         }
 
-        Bounds planeBounds = planeRenderer.bounds;
-        float planeHeight = planeBounds.size.y;
-        float planeWidth = planeBounds.size.x;
+        missingRendererLogged = false;
+    }
 
-        // Get the frustum height at the distance of the plane from the camera
-        float frustumHeight = 2.0f * Mathf.Tan(mainCamera.fieldOfView * 0.5f * Mathf.Deg2Rad);
-        float frustumWidth = frustumHeight * mainCamera.aspect;
+    private void TryFitPlane(bool forceRefresh)
+    {
+        if (mainCamera == null)
+        {
+            if (!missingCameraLogged)
+            {
+                Debug.LogError("Main camera not assigned.");
+                missingCameraLogged = true;
+            }
+            return;
+        }
 
-        // Calculate the required distance from the camera to fit the plane
-        float requiredDistanceHeight = planeHeight / (2.0f * Mathf.Tan(mainCamera.fieldOfView * 0.5f * Mathf.Deg2Rad));
-        float requiredDistanceWidth = planeWidth / (2.0f * Mathf.Tan(mainCamera.fieldOfView * 0.5f * Mathf.Deg2Rad) / mainCamera.aspect);
+        missingCameraLogged = false;
+
+        if (planeTransform == null || planeRenderer == null)
+        {
+            CachePlaneReferences();
+            if (planeTransform == null || planeRenderer == null)
+            {
+                return;
+            }
+            forceRefresh = true;
+        }
+
+        Bounds bounds = planeRenderer.bounds;
+        bool needsUpdate = forceRefresh ||
+                           Mathf.Abs(mainCamera.fieldOfView - lastFieldOfView) > Mathf.Epsilon ||
+                           Mathf.Abs(mainCamera.aspect - lastAspect) > Mathf.Epsilon ||
+                           bounds.size != lastBoundsSize ||
+                           bounds.center != lastBoundsCenter ||
+                           planeTransform.hasChanged;
+
+        if (!needsUpdate)
+        {
+            return;
+        }
+
+        FitPlane(bounds);
+
+        lastFieldOfView = mainCamera.fieldOfView;
+        lastAspect = mainCamera.aspect;
+        lastBoundsSize = bounds.size;
+        lastBoundsCenter = bounds.center;
+        planeTransform.hasChanged = false;
+    }
+
+    private void FitPlane(Bounds planeBounds)
+    {
+        float halfVerticalFov = mainCamera.fieldOfView * 0.5f * Mathf.Deg2Rad;
+        float tanHalfVerticalFov = Mathf.Tan(halfVerticalFov);
+
+        float requiredDistanceHeight = planeBounds.size.y * 0.5f / tanHalfVerticalFov;
+        float requiredDistanceWidth = planeBounds.size.x * 0.5f / (tanHalfVerticalFov * mainCamera.aspect);
         float requiredDistance = Mathf.Max(requiredDistanceHeight, requiredDistanceWidth);
 
-        // Set the parent's position
-        //Vector3 direction = (planeTransform.position - mainCamera.transform.position).normalized;
-        Vector3 direction = new Vector3(0, 0, 1);
+        Vector3 direction = new Vector3(0f, 0f, 1f);
         transform.position = mainCamera.transform.position + direction * requiredDistance;
-
-        // Correct the plane position to keep the parent-child relationship
-        //planeTransform.localPosition = Vector3.zero;
     }
 }


### PR DESCRIPTION
## Summary
- reduce redundant recalculations when fitting the vision plane to the camera and avoid repeated error logging
- recompute the box collider alignment only when the screen or collider changes and derive the orthographic size analytically
- cache camera references for drag handling and update the window manager offset only when children move

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cd124afa008332bf064765acd2152e